### PR TITLE
docs: document the distributed MPI/SLEPc eigensolver backend

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -123,6 +123,7 @@ makedocs(
                 "Equation DSL"                  => "equation_dsl.md",
                 "Spectral Operators"            => "matrices.md",
                 "Eigenvalue Solver"             => "method.md",
+                "Distributed (MPI)"             => "mpi.md",
                 "Performance & Sparsity"        => "performance.md",
                 "Utility functions"             => "basic_functionality.md",
                 "API Reference"                 => "modules/BiGSTARS.md",

--- a/docs/src/mpi.md
+++ b/docs/src/mpi.md
@@ -1,0 +1,38 @@
+# Distributed (MPI) eigensolver
+
+For problems too large for the in-process backends, BiGSTARS can run the
+eigensolve across MPI ranks using SLEPc over PETSc. Assembly stays serial on
+rank 0; the shift-and-invert factorization and Krylov eigensolve are distributed.
+
+## Requirements
+
+- A **complex-scalar** system build of PETSc and SLEPc
+  (`./configure --with-scalar-type=complex`), with `PETSC_DIR`, `PETSC_ARCH`,
+  and `SLEPC_DIR` exported.
+- Julia packages `MPI`, `PetscWrap`, `SlepcWrap` installed. Importing all three
+  activates the `BiGSTARSMPIExt` extension and the `solve_mpi` entrypoint.
+
+## Usage
+
+```julia
+using BiGSTARS, MPI, PetscWrap, SlepcWrap
+
+SlepcInitialize()
+cache = discretize(prob)
+results = solve_mpi(cache, k_values;
+                    sigma_0=0.02, nev=5, which=:LM,
+                    tol=1e-10, mat_solver=:mumps)
+# results is fully populated on rank 0; other ranks get empty markers.
+SlepcFinalize()
+```
+
+Run with `mpiexec -n P julia --project=. script.jl`.
+
+## Notes
+
+- `which=:LM` targets eigenvalues nearest `sigma_0` (shift-and-invert), matching
+  the serial backends. `:LR`/`:SR`/`:LI`/`:SI` select by real/imaginary extremes.
+- `mat_solver` picks the parallel direct solver for the inner solves
+  (`:mumps`, `:superlu_dist`, or `:petsc`).
+- v1 does a single solve at `sigma_0` (no adaptive-σ retry) and gathers
+  eigenvectors to rank 0 for reconstruction.


### PR DESCRIPTION
Add docs/src/mpi.md (requirements, usage, option notes) and wire it into the Documenter nav after the Eigenvalue Solver page.