### PR TITLE
Release v4.0.0 — SLEPc/PETSc sole eigensolver (breaking)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BiGSTARS"
 uuid = "55e6fa54-20b2-4a8e-ba84-e72db1c430e6"
-version = "3.0.9"
+version = "4.0.0"
 authors = ["Subhajit Kar <subhajitkar19@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Version bump `3.0.9` → **`4.0.0`** for the SLEPc-only rework (#73/#74/#75).

**Breaking** (SemVer major): removed `KrylovKit`/`ArnoldiMethod`/`Arpack`, `EigenSolver`/`SolverConfig`/`solve!`/`compare_methods!`/`get_results`, and `solve_mpi`. SLEPc/PETSc is now the sole eigensolver via `solve`.

After this merges, register to cut the tag:
1. Comment `@JuliaRegistrator register` on the merge commit.
2. TagBot tags `v4.0.0` → docs redeploy builds the versioned site and refreshes **`stable`**, removing `solve_mpi` from the published stable docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)