### PR TITLE
fix(docs): allow BiGSTARS v4 in docs env compat

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,7 +8,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-BiGSTARS = "3.0.0"
+BiGSTARS = "3, 4"
 Documenter = "1"
 DocumenterCitations = "1.2"
 Literate = "≥2.9.0"


### PR DESCRIPTION
`docs/Project.toml` pinned `BiGSTARS = "3.0.0"`; after the v4.0.0 bump, the docs build's `Pkg.develop(path=".")` failed with *empty intersection between BiGSTARS@4.0.0 and project compatibility 3*. Widened to `"3, 4"`.

Unblocks the docs build (and the versioned `stable` build for the v4.0.0 tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)