### PR TITLE
fix(solver): non-degenerate adaptive-σ schedule when σ₀ == 0

### DIFF
--- a/src/mpi_prep.jl
+++ b/src/mpi_prep.jl
@@ -85,12 +85,14 @@ end
     _sigma_schedule(σ₀, n_tries, Δσ₀, incre) -> Vector{Float64}
 
 Adaptive shift schedule: `σ₀` first, then `n_tries` geometrically growing
-increments above and below it (`Δσ₀ * incre^(i-1) * |σ₀|`). Pure-Julia, so the
-adaptive-σ logic is unit-tested without PETSc. Mirrors the schedule the old
-serial solver used.
+increments above and below it (`Δσ₀ * incre^(i-1) * base`, where `base = |σ₀|`,
+floored to `1.0` when `σ₀ == 0` so the retries actually vary instead of all
+re-targeting zero). Pure-Julia, so the adaptive-σ logic is unit-tested without
+PETSc. Mirrors the schedule the old serial solver used.
 """
 function _sigma_schedule(σ₀::Real, n_tries::Integer, Δσ₀::Real, incre::Real)
-    up = Float64[Δσ₀ * incre^(i - 1) * abs(σ₀) for i in 1:n_tries]
+    base = abs(σ₀) > 0 ? abs(σ₀) : 1.0
+    up = Float64[Δσ₀ * incre^(i - 1) * base for i in 1:n_tries]
     return vcat(Float64(σ₀), σ₀ .+ up, σ₀ .- up)
 end
 

--- a/test/test_mpi_prep.jl
+++ b/test/test_mpi_prep.jl
@@ -102,6 +102,8 @@ using LinearAlgebra
         # schedule scales with |σ₀|; n_tries=0 → just [σ₀]
         @test BiGSTARS._sigma_schedule(-2.0, 1, 0.5, 1.0) == [-2.0, -1.0, -3.0]
         @test BiGSTARS._sigma_schedule(3.0, 0, 0.2, 1.2) == [3.0]
+        # σ₀ = 0: base floors to 1.0 so the retry shifts still vary (not all zero)
+        @test BiGSTARS._sigma_schedule(0.0, 2, 0.2, 1.2) == [0.0, 0.2, 0.24, -0.2, -0.24]
     end
 
     @testset "solve without the extension throws an install hint" begin


### PR DESCRIPTION
Post-merge correctness audit follow-up.

`_sigma_schedule` scaled each retry step by `|σ₀|`, so `σ₀ = 0` produced an all-zero schedule — every adaptive attempt re-targeted 0 with no shift variation (so a failed solve at 0 had no fallback). Floor the step base to `1.0` when `σ₀ == 0`. `σ₀ ≠ 0` is unchanged. Pre-existing behavior carried from the old serial solver; fixed before the v4.0.0 release.

Adds a `σ₀=0` unit test. Cross-platform suite 851/851.

The audit otherwise confirmed the implementation correct: MPI collective-safety (no deadlock paths), resource lifecycle, FFI signatures, CSR round-trip, complex eigenvalue extraction — plus `mpi.yml` green at n=1/n=2 vs the analytic reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)