### PR TITLE
chore: remove dead _total_k_power helper

### DIFF
--- a/src/discretize.jl
+++ b/src/discretize.jl
@@ -68,8 +68,6 @@ function DiscretizationCache(A_components::Dict{KPowerKey, SparseMatrixCSC{Compl
                                N_total, N_per_var, N_vars, domain, derived_var_order, nothing)
 end
 
-_total_k_power(key::KPowerKey) = sum(last, key; init=0)
-
 function _k_coeff(key::KPowerKey, k_vals::Dict{Symbol, Float64})
     coeff = 1.0
     for (name, power) in key


### PR DESCRIPTION
Removes the unused `_total_k_power` helper from `src/discretize.jl`.

Dead since #85's alloc-reduction refactor collapsed the k-power cache — zero callers across `src/`, `ext/`, `test/` (verified via `git grep`). This was the only net change remaining in #86, which is now closed as superseded by #85; extracted here as a clean one-liner to avoid #86's conflict with #85's rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)