### PR TITLE
test: discretize allocation regression guard + v4.0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BiGSTARS"
 uuid = "55e6fa54-20b2-4a8e-ba84-e72db1c430e6"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["Subhajit Kar <subhajitkar19@gmail.com>"]
 
 [deps]

--- a/test/test_discretize.jl
+++ b/test/test_discretize.jl
@@ -439,4 +439,29 @@ using BiGSTARS: conversion_operator, differentiation_operator, get_conversion_op
         @test cache.derived_var_order == Symbol[]
     end
 
+    @testset "discretize allocation stays bounded (no += churn)" begin
+        # Measured green ratio ≈ 25.14×; old += churn was ~35×+ of component
+        # bytes per bucket, giving a ratio far above 38. THRESHOLD = 38 =
+        # ceil(25.14 * 1.5) provides headroom above COO path while still
+        # catching any regression to the churn pattern.
+        dom = Domain(x = FourierTransformed(),
+                     y = Fourier(12, [0.0, 2π]),
+                     z = Chebyshev(8, [0.0, 1.0]))
+        prob = EVP(dom, variables = [:w, :b], eigenvalue = :Ra)
+        Y, Z = meshgrid(dom, :y, :z)
+        prob[:F] = vec(@. exp(-((Y - π)^2)))          # y-varying field → multiple terms/key
+        @substitution D2(A) = dx(dx(A)) + dy(dy(A)) + dz(dz(A))
+        @equation Ra * w = D2(w) + F * dy(b)
+        @equation 0 = b + D2(b) - F * w
+        @bc left(w) = 0; @bc right(w) = 0
+        @bc left(b) = 0; @bc right(b) = 0
+
+        discretize(prob)                               # warm up (compile)
+        bytes  = @allocated discretize(prob)
+        cache  = discretize(prob)
+        steady = (sum(nnz, values(cache.A_components)) +
+                  sum(nnz, values(cache.B_components))) * 16   # ComplexF64 = 16 bytes
+        @test bytes < 38 * steady   # green ratio ≈ 25.14×; old += churn was ~35×+ → ratio >> 38
+    end
+
 end


### PR DESCRIPTION
Follow-up to the k-component allocation refactor (**#85**) and the dead-helper cleanup (**#87**), both already merged to `main`. This adds the regression guard that was the last task of that work, plus the release version bump.

### Changes
- **`test/test_discretize.jl`** — new testset *"discretize allocation stays bounded (no += churn)"*. Bounds `@allocated discretize(prob)` at **38× the final component nnz** for a small y-varying 2-var problem (multiple terms per k-power bucket — the churn-prone case). Measured green ratio ≈ **25×**; the old `components[key] = components[key] + block` churn (~35× per bucket) plus the duplicate dict pushed the ratio far above 38, so the guard catches a regression to either pattern. Threshold + calibration documented inline.
- **`Project.toml`** — `4.0.1` → **`4.0.2`**.

### Context (auto-sync note)
The alloc refactor (COO-triplet accumulation, single `KPowerKey` component dict, removal of the dead `assemble!`/`AssemblyWorkspace`/`allocate_workspace` serial-dense API) landed on `main` via #85; `_total_k_power` removal via #87. This PR is only the regression test + version bump on top.

### Release notes (already on main via #85, released by this bump)
- **BREAKING:** `DiscretizationCache` k-power components are now a single `Dict{KPowerKey, SparseMatrixCSC{ComplexF64,Int}}` pair `A_components`/`B_components` (was a duplicate Int-keyed + KPowerKey-keyed pair). Index by KPowerKey tuple: `cache.A_components[(:k_x => 2,)]`, `()` for k⁰.
- **BREAKING:** removed exports `assemble!`, `allocate_workspace`, `AssemblyWorkspace` (in-place dense API for the removed serial dense eigensolvers). Use `assemble(cache; k...)`.
- Internal: `discretize()` accumulates via COO scatter instead of sparse `+=` — assembled `(A,B)` unchanged, build-time allocation cut ~3× on large problems.

### Test plan
- [x] Full `Pkg.test()` green (999/999) on `main` + this change.
- [ ] CI green (the guard runs in the standard suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)