### PR TITLE
Opt-in build-sparsity threshold (coeff_tol) for y-varying fields

### DIFF
--- a/src/discretize.jl
+++ b/src/discretize.jl
@@ -45,9 +45,10 @@ mutable struct DiscretizationContext
     s_inv_full_cache::Dict{Int, SparseMatrixCSC{ComplexF64, Int}}  # S_inv_full (N_per_var) per cheb_order
     sinv_1d_cache::Dict{Int, SparseMatrixCSC{ComplexF64, Int}}     # S_inv_1d (N_z) per cheb_order
     s_mf_sinv_cache::Dict{FieldOpCacheKey, SparseMatrixCSC{ComplexF64, Int}}  # S*M_f*S_inv per (field, order)
+    coeff_tol::Float64                                                        # Fourier-block drop tolerance (0 = exact)
 end
 
-function DiscretizationContext()
+function DiscretizationContext(coeff_tol::Float64=0.0)
     return DiscretizationContext(
         Dict{FieldMultiplyCacheKey, SparseMatrixCSC{ComplexF64, Int}}(),
         0,
@@ -56,8 +57,12 @@ function DiscretizationContext()
         Dict{Int, SparseMatrixCSC{ComplexF64, Int}}(),
         Dict{Int, SparseMatrixCSC{ComplexF64, Int}}(),
         Dict{FieldOpCacheKey, SparseMatrixCSC{ComplexF64, Int}}(),
+        coeff_tol,
     )
 end
+
+# coeff_tol carried on the (per-call) ctx; nothing → exact.
+_ctx_coeff_tol(ctx::Union{Nothing, DiscretizationContext}) = ctx === nothing ? 0.0 : ctx.coeff_tol
 
 function DiscretizationCache(A_components::Dict{KPowerKey, SparseMatrixCSC{ComplexF64, Int}},
                              B_components::Dict{KPowerKey, SparseMatrixCSC{ComplexF64, Int}},
@@ -535,7 +540,7 @@ State vector ordering: z varies fastest.
 """
 function _build_2d_field_multiply(f_vec::AbstractVector, domain::Domain,
                                    cheb_dim::Symbol, fourier_dim::Symbol,
-                                   highest_cheb_order::Int)
+                                   highest_cheb_order::Int; coeff_tol::Float64=0.0)
     spec_z = domain.coords[cheb_dim]
     spec_y = domain.coords[fourier_dim]
     N_z = spec_z.N
@@ -567,7 +572,7 @@ function _build_2d_field_multiply(f_vec::AbstractVector, domain::Domain,
         Mz_blocks[dm + 1] = S_1d * M_z
     end
 
-    return _assemble_2d_block_toeplitz(Mz_blocks, N_z, N_y)
+    return _assemble_2d_block_toeplitz(Mz_blocks, N_z, N_y; coeff_tol=coeff_tol)
 end
 
 """
@@ -578,7 +583,8 @@ Fourier mode of the field — avoiding the dense inverse-conversion `S_z⁻¹` a
 keeping the operator sparse (fill ∝ band/N_z).
 """
 function _build_2d_field_multiply_banded(f_vec::AbstractVector, domain::Domain,
-                                         cheb_dim::Symbol, fourier_dim::Symbol, λ::Int)
+                                         cheb_dim::Symbol, fourier_dim::Symbol, λ::Int;
+                                         coeff_tol::Float64=0.0)
     N_z = domain.coords[cheb_dim].N
     N_y = domain.coords[fourier_dim].N
 
@@ -596,7 +602,7 @@ function _build_2d_field_multiply_banded(f_vec::AbstractVector, domain::Domain,
         Mz_blocks[dm + 1] = ultraspherical_multiplication_operator(c, N_z, λ)
     end
 
-    return _assemble_2d_block_toeplitz(Mz_blocks, N_z, N_y)
+    return _assemble_2d_block_toeplitz(Mz_blocks, N_z, N_y; coeff_tol=coeff_tol)
 end
 
 """
@@ -606,7 +612,8 @@ the caller's fallback). Unifies the 1D (z-only, lifted) and 2D (varies in y and
 z) cases; both stay sparse (banded ultraspherical, no dense `S⁻¹`).
 """
 function _field_banded_operator(param::ParamNode, prob::EVP, cheb_dim::Symbol,
-                                highest_cheb_order::Int, N_per_var::Int)
+                                highest_cheb_order::Int, N_per_var::Int;
+                                coeff_tol::Float64=0.0)
     highest_cheb_order >= 1 || return nothing
     domain = prob.domain
     N_z = domain.coords[cheb_dim].N
@@ -620,7 +627,8 @@ function _field_banded_operator(param::ParamNode, prob::EVP, cheb_dim::Symbol,
         return size(M_z, 1) == N_per_var ? M_z : _lift_to_2d(M_z, cheb_dim, domain)
     else
         # 2D (y, z) field
-        return _build_2d_field_multiply_banded(f_vec, domain, cheb_dim, fourier_dim, highest_cheb_order)
+        return _build_2d_field_multiply_banded(f_vec, domain, cheb_dim, fourier_dim, highest_cheb_order;
+                                               coeff_tol=coeff_tol)
     end
 end
 
@@ -632,7 +640,8 @@ order ≥ 1; falls back to the T-basis multiply (`S·M_f·S⁻¹`) for order 0.
 function _field_times_operator(param::ParamNode, G, prob::EVP, cheb_dim::Symbol,
                                highest_cheb_order::Int, N_per_var::Int,
                                ctx::Union{Nothing, DiscretizationContext})
-    banded = _field_banded_operator(param, prob, cheb_dim, highest_cheb_order, N_per_var)
+    banded = _field_banded_operator(param, prob, cheb_dim, highest_cheb_order, N_per_var;
+                                    coeff_tol=_ctx_coeff_tol(ctx))
     isnothing(banded) || return banded * G
     M_f = _field_multiply_T(param, ComplexF64(1.0), prob, cheb_dim, ctx)
     return _apply_field_multiply(M_f, G, prob.domain, cheb_dim, highest_cheb_order,
@@ -665,12 +674,32 @@ function _build_2d_coeff_multiply(c_vec::AbstractVector, domain::Domain,
 end
 
 function _assemble_2d_block_toeplitz(Mz_blocks::AbstractVector{<:SparseMatrixCSC{ComplexF64, Int}},
-                                     N_z::Int, N_y::Int)
+                                     N_z::Int, N_y::Int; coeff_tol::Float64=0.0)
     length(Mz_blocks) == N_y ||
         throw(DimensionMismatch("Expected $N_y Fourier blocks, got $(length(Mz_blocks))"))
 
+    # Relative drop of near-zero Fourier-mode blocks: treat block dm as zero when its norm is
+    # ≤ coeff_tol × the largest block norm — truncating the field's y-spectrum (smooth field ⇒
+    # exponential decay ⇒ tiny error). Reference is the MAX block (not DC: zero-mean fields have
+    # DC ≈ 0). coeff_tol = 0 keeps every nonzero block (exact, current behavior).
+    keep = trues(N_y)
+    if coeff_tol > 0
+        norms = [iszero(nnz(b)) ? 0.0 : norm(nonzeros(b)) for b in Mz_blocks]
+        mx = maximum(norms)
+        if mx > 0
+            for dm in 1:N_y
+                keep[dm] = norms[dm] > coeff_tol * mx
+            end
+            ndrop = count(!, keep)
+            if ndrop > 0
+                kept_frac = sqrt(sum(abs2, norms[keep]) / sum(abs2, norms))
+                @debug "block-Toeplitz coeff_tol drop" coeff_tol kept=(N_y - ndrop) total=N_y dropped_frac=(1 - kept_frac)
+            end
+        end
+    end
+
     N_total = N_z * N_y
-    estimated_nnz = N_y * sum(nnz, Mz_blocks)
+    estimated_nnz = N_y * sum(dm -> keep[dm] ? nnz(Mz_blocks[dm]) : 0, 1:N_y)
     rows = Int[]
     cols = Int[]
     vals = ComplexF64[]
@@ -686,7 +715,7 @@ function _assemble_2d_block_toeplitz(Mz_blocks::AbstractVector{<:SparseMatrixCSC
             block = Mz_blocks[dm + 1]
             size(block) == (N_z, N_z) ||
                 throw(DimensionMismatch("Block $(dm + 1) has size $(size(block)), expected ($N_z, $N_z)"))
-            nnz(block) == 0 && continue
+            (nnz(block) == 0 || !keep[dm + 1]) && continue
 
             row_offset = m1 * N_z
             col_offset = m2 * N_z
@@ -851,7 +880,8 @@ function _field_multiply_T(param::ParamNode, scale::ComplexF64, prob::EVP, cheb_
     M = if !isnothing(fourier_dim)
         N_y = domain.coords[fourier_dim].N
         if length(f_vec) == N_y * N_z
-            _build_2d_field_multiply(f_vec, domain, cheb_dim, fourier_dim, 0)
+            _build_2d_field_multiply(f_vec, domain, cheb_dim, fourier_dim, 0;
+                                     coeff_tol=_ctx_coeff_tol(ctx))
         elseif length(f_vec) == N_z
             c = chebyshev_coefficients(Float64.(f_vec))
             ComplexF64.(multiplication_operator(c, N_z))
@@ -1700,7 +1730,9 @@ but denser system). The augmented form is a singular-`B` descriptor system; `sol
 filters the resulting infinite/spurious modes, but shift-target the physical region.
 """
 function discretize(prob::EVP; augment_derived::Bool=true,
-                    row_range::Union{Nothing,Tuple{Int,Int}}=nothing)
+                    row_range::Union{Nothing,Tuple{Int,Int}}=nothing,
+                    coeff_tol::Float64=0.0)
+    (0.0 <= coeff_tol < 1.0) || throw(ArgumentError("coeff_tol=$(coeff_tol) must be in [0, 1)"))
     validate_problem(prob)
 
     # Augmented (descriptor) form: rewrite derived variables into regular
@@ -1725,7 +1757,7 @@ function discretize(prob::EVP; augment_derived::Bool=true,
 
     A_buffers = Dict{KPowerKey, _COOBuf}()
     B_buffers = Dict{KPowerKey, _COOBuf}()
-    ctx = DiscretizationContext()
+    ctx = DiscretizationContext(coeff_tol)
 
     # Compute per-equation highest Chebyshev derivative order.
     # Each equation lives in its own C^(p) basis where p is the max z-derivative

--- a/test/test_discretize.jl
+++ b/test/test_discretize.jl
@@ -593,4 +593,85 @@ using BiGSTARS: conversion_operator, differentiation_operator, get_conversion_op
         @test_throws ArgumentError assemble(restricted, 1.0)
     end
 
+    @testset "_assemble_2d_block_toeplitz coeff_tol drops near-zero Fourier blocks" begin
+        N_z, N_y = 2, 4
+        # Block norms decay geometrically; dm=0 (DC) is ZERO to confirm the reference
+        # is the max block, not DC. Each nonzero block = m·I (nnz = N_z).
+        mags = [0.0, 1.0, 1e-3, 1e-9]      # block norms for dm = 0,1,2,3
+        Mz = [ m == 0.0 ? spzeros(ComplexF64, N_z, N_z) :
+                          sparse(ComplexF64(m) * I, N_z, N_z) for m in mags ]
+
+        full = BiGSTARS._assemble_2d_block_toeplitz(Mz, N_z, N_y)                    # exact
+        cut  = BiGSTARS._assemble_2d_block_toeplitz(Mz, N_z, N_y; coeff_tol=1e-6)    # drop dm=3 (1e-9)
+        keepall = BiGSTARS._assemble_2d_block_toeplitz(Mz, N_z, N_y; coeff_tol=1e-12)
+
+        # each nonzero dm-block appears at N_y positions in the block-Toeplitz
+        @test nnz(full)    == N_y * (nnz(Mz[2]) + nnz(Mz[3]) + nnz(Mz[4]))  # dm=1,2,3
+        @test nnz(cut)     == N_y * (nnz(Mz[2]) + nnz(Mz[3]))               # dm=3 dropped
+        @test nnz(keepall) == nnz(full)                                     # nothing below 1e-12·max
+        @test nnz(cut) < nnz(full)
+    end
+
+    @testset "discretize coeff_tol: sparser operator, eigenvalues preserved" begin
+        dom = Domain(x=FourierTransformed(), y=Fourier(16,[0.0,2π]), z=Chebyshev(12,[0.0,1.0]))
+        p = EVP(dom, variables=[:u], eigenvalue=:sigma)
+        # Smooth periodic background with exponentially decaying Fourier modes.
+        # DFT modes at dm=4 and dm=12 have amplitude ~1e-10 (below coeff_tol=1e-8 × max),
+        # so those Toeplitz blocks get dropped. A plain Gaussian on [0,2π] is not periodic —
+        # its periodic extension has a C^1 kink → polynomial Fourier decay floor ~6e-4 that
+        # never drops below 1e-8 within N_y=16; we use an explicit trig polynomial instead.
+        y = gridpoints(dom, :y)
+        U_y = @. 1.0 + 0.5*cos(y - π) + 0.05*cos(2*(y - π)) +
+                  0.001*cos(3*(y - π)) + 1e-10*cos(4*(y - π))
+        p[:U] = vec([U_y[iy] for iz in 1:12, iy in 1:16])
+        @equation p sigma * u == -dz(dz(u)) - dx(dx(u)) + U * u
+        @bc p left(u) == 0
+        @bc p right(u) == 0
+
+        c0 = discretize(p)                                 # exact
+        ct = discretize(p; coeff_tol=1e-8)                 # thresholded
+
+        nnz0 = sum(nnz, values(c0.A_components))
+        nnzt = sum(nnz, values(ct.A_components))
+        @test nnzt < nnz0                                  # blocks were dropped
+
+        # Filter out spurious BC-constraint eigenvalues (|λ| ≥ 1e6) before comparing
+        leading(A, B) = begin
+            e = eigvals(Matrix(A), Matrix(B))
+            e = filter(l -> isfinite(l) && abs(l) < 1e6, e)
+            e[argmax(real.(e))]
+        end
+        A0, B0 = assemble(c0, 0.5); At, Bt = assemble(ct, 0.5)
+        λ0 = leading(A0, B0); λt = leading(At, Bt)
+        rel_t = abs(λt - λ0) / abs(λ0)
+        @test rel_t < 1e-6                                 # accuracy preserved
+
+        # Load-bearing accuracy/sparsity trade: coeff_tol=1e-3 drops a MORE significant mode
+        # (±3, DFT amp ~5e-4) on top of ±4, while keeping ±2 (~0.025). It must be strictly
+        # sparser than the 1e-8 build AND shift the eigenvalue strictly more (a real mode left)
+        # — yet stay well within tolerance. This makes the trade non-vacuous: dropping ±2/±1
+        # would breach 1e-2, dropping nothing extra would fail the nnz check.
+        c3 = discretize(p; coeff_tol=1e-3)
+        @test sum(nnz, values(c3.A_components)) < nnzt     # ±3 pair dropped on top of ±4
+        A3, B3 = assemble(c3, 0.5); λ3 = leading(A3, B3)
+        rel_3 = abs(λ3 - λ0) / abs(λ0)
+        @test rel_3 > rel_t                                # bigger mode dropped → strictly larger shift
+        @test rel_3 < 1e-2                                 # still bounded / accurate
+
+        # zero-mean field: DC ≈ 0, so the max-reference (not DC) must still keep dominant modes
+        p2 = EVP(dom, variables=[:u], eigenvalue=:sigma)
+        U_raw = p.parameters[:U]
+        Uz = U_raw .- sum(U_raw) / length(U_raw)
+        p2[:U] = Uz
+        @equation p2 sigma * u == -dz(dz(u)) - dx(dx(u)) + U * u
+        @bc p2 left(u) == 0
+        @bc p2 right(u) == 0
+        cz = discretize(p2; coeff_tol=1e-8)
+        @test sum(nnz, values(cz.A_components)) > 0        # not everything dropped (max ref works)
+
+        # coeff_tol must be in [0, 1)
+        @test_throws ArgumentError discretize(p; coeff_tol=1.0)
+        @test_throws ArgumentError discretize(p; coeff_tol=-0.1)
+    end
+
 end


### PR DESCRIPTION
## Summary
`discretize(prob; coeff_tol=τ)` drops near-zero Fourier-mode blocks of a y-varying coefficient operator (block norm ≤ τ × the dominant mode's) in `_assemble_2d_block_toeplitz`, truncating the field's y-spectrum. For smooth fields (exponential spectral decay) this sparsifies the assembled operator — less build/MUMPS-factorization memory — at `O(τ)` eigenvalue error.

- Relative to the **max** mode, not DC, so zero-mean jets work; conjugate ±modes drop together.
- Threaded via the per-call `DiscretizationContext` to the field-multiply builders. Default `0` = exact (serial path byte-for-byte unchanged). Validated `0 ≤ coeff_tol < 1`.
- `discretize_distributed` forwards it via `kwargs`; `reconstruct.jl` / `_build_2d_coeff_multiply` left exact.

Builds on the row-restricted discretize work merged in #97.

## Test Plan
- [x] Leaf drop-selection unit test (zero-DC block proves the reference is max, not DC).
- [x] End-to-end: `coeff_tol=1e-8` strictly sparser + eigenvalues preserved; **load-bearing** accuracy — a larger `coeff_tol=1e-3` drops a more significant mode → strictly larger but bounded Δλ (`< 1e-2`).
- [x] Zero-mean field (max-reference); `[0,1)` validation throws.
- [x] Full suite green (1247/1247); default `coeff_tol=0` unchanged.

Note: a plain Gaussian on a periodic domain is not periodic-smooth (C¹ kink → O(m⁻²) decay) so it won't drop at τ=1e-8; genuinely band-limited / very-smooth fields do. Pick τ per field; `@debug` reports the dropped fraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)