### PR TITLE
Opt-in symbolic-factorization reuse across the k-sweep

### DIFF
--- a/.github/workflows/mpi.yml
+++ b/.github/workflows/mpi.yml
@@ -103,3 +103,12 @@ jobs:
 
       - name: Run integration test (n=4, groups)
         run: mpiexec --oversubscribe -n 4 julia --project=test/mpi test/mpi/test_slepc.jl
+
+      - name: Run reuse_factorization test (n=1)
+        run: mpiexec -n 1 julia --project=test/mpi test/mpi/test_slepc_reuse.jl
+
+      - name: Run reuse_factorization test (n=2)
+        run: mpiexec --oversubscribe -n 2 julia --project=test/mpi test/mpi/test_slepc_reuse.jl
+
+      - name: Run reuse_factorization test (n=4, groups)
+        run: mpiexec --oversubscribe -n 4 julia --project=test/mpi test/mpi/test_slepc_reuse.jl

--- a/ext/BiGSTARSMPIExt.jl
+++ b/ext/BiGSTARSMPIExt.jl
@@ -4,7 +4,7 @@ using BiGSTARS
 using BiGSTARS: _to_csr, _csr_block_nnz_split, _eps_options,
                 _sigma_schedule, _group_indices, _petsc_ownership, assemble_rows,
                 SolverResults, ConvergenceHistory, _keep_by_mass,
-                sort_eigenvalues!, _discretize_n_total
+                sort_eigenvalues!, _discretize_n_total, _union_block_nnz
 using MPI
 using PetscWrap
 using SlepcWrap
@@ -60,6 +60,32 @@ function _fill_mat!(M, rows, rstart::Integer, rend::Integer, comm::MPI.Comm)
     MatAssemblyBegin(M, MAT_FINAL_ASSEMBLY)
     MatAssemblyEnd(M, MAT_FINAL_ASSEMBLY)
     return M
+end
+
+"""Refill an existing PETSc matrix `M`'s values in place for a new wavenumber: zero the
+numeric values (structure/preallocation preserved) and insert the owned-row slice `rows`.
+No reallocation — `M` must already be preallocated for the UNION pattern (see
+`_create_union_mat`), a superset of every per-k pattern."""
+function _refill_mat!(M, rows, rstart::Integer, rend::Integer)
+    MatZeroEntries(M)
+    rowptr, colind, vals = _to_csr(rows)
+    _insert_rows!(M, rstart, rowptr, colind, vals)
+    MatAssemblyBegin(M, MAT_FINAL_ASSEMBLY)
+    MatAssemblyEnd(M, MAT_FINAL_ASSEMBLY)
+    return M
+end
+
+"""Create a distributed PETSc matrix preallocated ONCE for the union of all `components`'
+k-power patterns (constant across the sweep), so values can be refilled per wavenumber with
+`_refill_mat!` without growing rows. Returns `(M, rstart, rend)` (owned 0-based row range)."""
+function _create_union_mat(components, N::Integer, comm::MPI.Comm)
+    M = MatCreate(comm)
+    MatSetSizes(M, PETSC_DECIDE, PETSC_DECIDE, PetscInt(N), PetscInt(N))
+    MatSetFromOptions(M)
+    rstart, rend = MatGetOwnershipRange(M)
+    d_nnz, o_nnz = _union_block_nnz(components, rstart, rend, N)
+    _prealloc!(M, MPI.Comm_size(comm), d_nnz, o_nnz) || MatSetUp(M)
+    return M, rstart, rend
 end
 
 """Build distributed PETSc A and B for one wavenumber, each rank assembling only
@@ -165,22 +191,19 @@ end
 # ------------------------------------------------------------------------------
 
 """
-    _solve_one_adaptive(cache, k, N, comm; sigma_0, n_tries, Δσ₀, incre, ϵ, verbose)
+    _run_sigma_schedule(eps, A, B, k, N, comm; sigma_0, n_tries, Δσ₀, incre, ϵ, verbose)
         -> SolverResults
 
-Build the distributed pencil once, then sweep the σ schedule. Each attempt
-retargets SLEPc via `EPSSetTarget` and re-solves; rank 0 filters spurious modes,
-sorts nearest σ, and decides whether to stop (successive |Δλ₁| < ϵ). The stop
-flag is BROADCAST so every rank's control flow is identical — required, or the
-collective `EPSSolve`/`MatDestroy` calls desync and deadlock.
+Sweep the adaptive-σ schedule on a CALLER-OWNED, already-configured `eps` (operators set,
+`EPSSetFromOptions` done) and assembled `A`,`B`. Reuses `eps` across σ attempts via
+`EPSSetTarget`. Does NOT create/destroy `eps`/`A`/`B`. The stop flag is broadcast so every
+rank's control flow is identical (else collective `EPSSolve` desyncs/deadlocks).
 """
-function _solve_one_adaptive(cache, k, N::Integer, comm::MPI.Comm;
+function _run_sigma_schedule(eps, A, B, k, N::Integer, comm::MPI.Comm;
                              sigma_0, n_tries, Δσ₀, incre, ϵ, verbose)
     rank = MPI.Comm_rank(comm)
     t0 = MPI.Wtime()
-    A, B = _build_petsc_mats_local(cache, k, N, comm)
     schedule = _sigma_schedule(sigma_0, n_tries, Δσ₀, incre)
-
     hist = ConvergenceHistory()
     λ_prev = nothing
     best_λ = ComplexF64[]
@@ -188,14 +211,10 @@ function _solve_one_adaptive(cache, k, N::Integer, comm::MPI.Comm;
     final_shift = Float64(sigma_0)
 
     for σ in schedule
-        eps = EPSCreate(comm)
-        EPSSetOperators(eps, A, B)
         EPSSetTarget(eps, PetscScalar(σ))
-        EPSSetFromOptions(eps)
         EPSSolve(eps)
         nconv = EPSGetConverged(eps)
         λ, Χ, masses = _gather_eigenpairs(eps, A, B, nconv, N, comm)
-        EPSDestroy(eps)
 
         stop = false
         if rank == 0
@@ -221,14 +240,11 @@ function _solve_one_adaptive(cache, k, N::Integer, comm::MPI.Comm;
                 verbose && @printf("  ✗ σ=%.6f  no convergence\n", σ)
             end
         end
-        stop = MPI.bcast(stop, 0, comm)   # collective: identical control flow on every rank
+        stop = MPI.bcast(stop, 0, comm)
         stop && break
     end
 
     solve_time = MPI.Wtime() - t0
-    MatDestroy(A)
-    MatDestroy(B)
-
     if rank == 0
         hist.final_shift = final_shift
         converged = !isempty(best_λ)
@@ -238,6 +254,56 @@ function _solve_one_adaptive(cache, k, N::Integer, comm::MPI.Comm;
         return SolverResults(ComplexF64[], zeros(ComplexF64, 0, 0), false, :Slepc,
                              final_shift, 0, solve_time, ConvergenceHistory())
     end
+end
+
+"""Non-reuse path (default): build per-k `A`,`B`, create a fresh `eps`, run the σ schedule,
+tear everything down. Behavior matches the prior per-k solve."""
+function _solve_one_adaptive(cache, k, N::Integer, comm::MPI.Comm;
+                             sigma_0, n_tries, Δσ₀, incre, ϵ, verbose)
+    A, B = _build_petsc_mats_local(cache, k, N, comm)
+    eps = EPSCreate(comm)
+    EPSSetOperators(eps, A, B)
+    EPSSetFromOptions(eps)
+    r = _run_sigma_schedule(eps, A, B, k, N, comm;
+                            sigma_0=sigma_0, n_tries=n_tries, Δσ₀=Δσ₀, incre=incre, ϵ=ϵ,
+                            verbose=verbose)
+    EPSDestroy(eps)
+    MatDestroy(A)
+    MatDestroy(B)
+    return r
+end
+
+"""Reuse path: preallocate `A`,`B` ONCE for the union pattern and create one `eps`, then per
+wavenumber in `ks` refill values in place and run the σ schedule on the same objects. With
+`-st_pc_factor_reuse_ordering` MUMPS reuses the LU ordering across wavenumbers. Returns one
+`SolverResults` per entry of `ks` (in order). Requires `isempty(cache.derived_caches)` —
+enforced by the `reuse_factorization` guard in `solve`."""
+function _solve_group_reused(cache, ks, N::Integer, comm::MPI.Comm;
+                             sigma_0, n_tries, Δσ₀, incre, ϵ, verbose)
+    A, rstart, rend = _create_union_mat(cache.A_components, N, comm)
+    B, rstartB, rendB = _create_union_mat(cache.B_components, N, comm)
+    (rstartB, rendB) == (rstart, rend) ||
+        error("PETSc returned different row ownership for A $((rstart, rend)) and " *
+              "B $((rstartB, rendB)) — cannot assemble the pencil.")
+    eps = EPSCreate(comm)
+    EPSSetOperators(eps, A, B)
+    EPSSetFromOptions(eps)
+
+    out = SolverResults[]
+    for k in ks
+        A_rows, B_rows = assemble_rows(cache, Float64(k), rstart, rend)
+        _refill_mat!(A, A_rows, rstart, rend)
+        _refill_mat!(B, B_rows, rstart, rend)
+        EPSSetOperators(eps, A, B)            # re-flag updated values (numeric refactor; ordering reused)
+        push!(out, _run_sigma_schedule(eps, A, B, Float64(k), N, comm;
+                                       sigma_0=sigma_0, n_tries=n_tries, Δσ₀=Δσ₀,
+                                       incre=incre, ϵ=ϵ, verbose=verbose))
+    end
+
+    EPSDestroy(eps)
+    MatDestroy(A)
+    MatDestroy(B)
+    return out
 end
 
 # ------------------------------------------------------------------------------
@@ -250,10 +316,12 @@ function BiGSTARS.solve(cache::BiGSTARS.DiscretizationCache,
                         tol::Real=1e-10, maxiter::Integer=300, ncv::Integer=0,
                         mat_solver::Symbol=:mumps, eps_type::Symbol=:krylovschur,
                         n_tries::Integer=8, Δσ₀::Real=0.2, incre::Real=1.2, ϵ::Real=1e-5,
-                        ngroups::Integer=1, manage_init::Bool=true, verbose::Bool=false)
+                        ngroups::Integer=1, manage_init::Bool=true,
+                        reuse_factorization::Bool=false, verbose::Bool=false)
     opts = _eps_options(; nev=Int(nev), which=which, tol=Float64(tol),
                         maxiter=Int(maxiter), ncv=Int(ncv),
-                        mat_solver=String(mat_solver), eps_type=String(eps_type))
+                        mat_solver=String(mat_solver), eps_type=String(eps_type),
+                        reuse_factorization=reuse_factorization)
 
     # MPI.jl populates COMM_WORLD only through its own MPI.Init(); the C-level
     # MPI_Init PETSc runs inside SlepcInitialize does NOT. Init MPI.jl first, then
@@ -279,6 +347,13 @@ function BiGSTARS.solve(cache::BiGSTARS.DiscretizationCache,
         end
     end
     _assert_complex_scalars()
+
+    if reuse_factorization && !isempty(cache.derived_caches)
+        error("solve: reuse_factorization=true is not supported for caches with derived-variable " *
+              "terms (non-empty derived_caches, i.e. discretize(...; augment_derived=false) with " *
+              "@derive vars) — their dense H(k) block is not in the union preallocation. " *
+              "Use augment_derived=true (the default) or reuse_factorization=false.")
+    end
 
     world = MPI.COMM_WORLD
     P = MPI.Comm_size(world)
@@ -308,15 +383,30 @@ function BiGSTARS.solve(cache::BiGSTARS.DiscretizationCache,
 
     # Each group solves its round-robin subset, sequentially, distributed on group_comm.
     local_pairs = Tuple{Int,SolverResults}[]
-    for i in _group_indices(nk, ngroups, group_id)
-        N = cache.N_total                          # replicated; no assemble-on-root, no bcast
+    idxs = _group_indices(nk, ngroups, group_id)
+    N = cache.N_total                              # replicated; no assemble-on-root, no bcast
+    if reuse_factorization
         verbose && grank == 0 &&
-            println("solve: group $(group_id)  k=$(k_values[i])  N=$(N)  σ₀=$(sigma_0)  nev=$(nev)")
-        r = _solve_one_adaptive(cache, Float64(k_values[i]), N, group_comm;
+            println("solve: group $(group_id)  reuse_factorization  $(length(idxs)) k-values  N=$(N)")
+        rs = _solve_group_reused(cache, [Float64(k_values[i]) for i in idxs], N, group_comm;
                         sigma_0=Float64(sigma_0), n_tries=Int(n_tries),
                         Δσ₀=Float64(Δσ₀), incre=Float64(incre), ϵ=Float64(ϵ),
                         verbose=verbose)
-        grank == 0 && push!(local_pairs, (i, r))
+        if grank == 0
+            for (j, i) in enumerate(idxs)
+                push!(local_pairs, (i, rs[j]))
+            end
+        end
+    else
+        for i in idxs
+            verbose && grank == 0 &&
+                println("solve: group $(group_id)  k=$(k_values[i])  N=$(N)  σ₀=$(sigma_0)  nev=$(nev)")
+            r = _solve_one_adaptive(cache, Float64(k_values[i]), N, group_comm;
+                            sigma_0=Float64(sigma_0), n_tries=Int(n_tries),
+                            Δσ₀=Float64(Δσ₀), incre=Float64(incre), ϵ=Float64(ϵ),
+                            verbose=verbose)
+            grank == 0 && push!(local_pairs, (i, r))
+        end
     end
 
     # Collect group-root results to global rank 0 (point-to-point over WORLD).

--- a/src/mpi_prep.jl
+++ b/src/mpi_prep.jl
@@ -82,6 +82,29 @@ function _csr_block_nnz_split(rowptr::AbstractVector{<:Integer},
 end
 
 """
+    _union_block_nnz(components, rstart, rend, N) -> (d_nnz, o_nnz)
+
+PETSc `d_nnz`/`o_nnz` for the UNION sparsity pattern of all k-power `components`
+(`Dict{KPowerKey,SparseMatrixCSC}`) over the owned global rows `[rstart,rend)`. Every
+per-wavenumber matrix is `Σ c_p(k)·components[p]`, whose pattern ⊆ this union — so a Mat
+preallocated from these counts covers every wavenumber's per-k pattern (no mid-insert growth
+when refilling values in place). Uses `abs.` accumulation so additive overlap never cancels
+the pattern; may over-count by structural zeros (conservative — safe for preallocation).
+Pure-Julia (no PETSc/MPI), unit-tested directly.
+"""
+function _union_block_nnz(components, rstart::Integer, rend::Integer, N::Integer)
+    nrows = rend - rstart
+    nrows ≥ 0 || throw(ArgumentError("rend ($rend) < rstart ($rstart)"))
+    U = spzeros(Float64, nrows, N)
+    for (_, M) in components
+        block = size(M, 1) == nrows ? M : M[(rstart + 1):rend, :]   # restricted vs full cache
+        U = U + abs.(block)
+    end
+    rowptr, colind, _ = _to_csr(U)
+    return _csr_block_nnz_split(rowptr, colind, 0, nrows, rstart, rend)
+end
+
+"""
     _group_indices(nk, ngroups, group_id) -> Vector{Int}
 
 1-based indices of `1:nk` assigned to group `group_id` (0-based) under a
@@ -139,7 +162,7 @@ const _WHICH_OPT = Dict(
 )
 
 """
-    _eps_options(; nev, which, tol, maxiter, ncv, mat_solver, eps_type) -> String
+    _eps_options(; nev, which, tol, maxiter, ncv, mat_solver, eps_type, reuse_factorization=false) -> String
 
 Build the PETSc/SLEPc options-database string that configures one distributed
 solve: Krylov-Schur EPS, shift-and-invert ST, with a parallel LU (direct)
@@ -148,7 +171,8 @@ is set per attempt via `EPSSetTarget`, so the static options stay invariant acro
 σ attempts and wavenumbers. Pure-Julia (no PETSc), so it is unit-tested while CI
 verifies the solve.
 """
-function _eps_options(; nev, which, tol, maxiter, ncv, mat_solver, eps_type)
+function _eps_options(; nev, which, tol, maxiter, ncv, mat_solver, eps_type,
+                      reuse_factorization::Bool=false)
     haskey(_WHICH_OPT, which) || throw(ArgumentError("unsupported which=$which"))
     opts = "-eps_type $(eps_type) " *
            "-eps_gen_non_hermitian " *                # generalized non-Hermitian pencil (EPS_GNHEP)
@@ -160,6 +184,11 @@ function _eps_options(; nev, which, tol, maxiter, ncv, mat_solver, eps_type)
            "-st_pc_type lu " *
            "-st_pc_factor_mat_solver_type $(mat_solver) "
     ncv > 0 && (opts *= "-eps_ncv $(ncv) ")
+    if reuse_factorization
+        # Reuse the LU ordering/fill across re-factorizations of a same-pattern operator
+        # (the k-sweep keeps the sparsity pattern fixed); MUMPS then redoes numeric only.
+        opts *= "-st_pc_factor_reuse_ordering true -st_pc_factor_reuse_fill true "
+    end
     return opts
 end
 

--- a/test/mpi/test_slepc_reuse.jl
+++ b/test/mpi/test_slepc_reuse.jl
@@ -1,0 +1,85 @@
+# Run with: mpiexec -n {1,2,4} julia --project=test/mpi test/mpi/test_slepc_reuse.jl
+# Validates the reuse_factorization=true solve path (persistent A/B/eps across a group's
+# wavenumbers, MUMPS ordering reused) against the analytic reference.
+#
+# reuse_factorization changes the PETSc options string, which is set ONCE per process — so
+# this runs in its OWN process (separate from test_slepc.jl, which exercises the non-reuse
+# path) and checks reuse against analytic σ_n directly, rather than diffing two solves.
+using BiGSTARS
+using MPI
+import PetscWrap, SlepcWrap
+using Test
+using LinearAlgebra
+
+MPI.Initialized() || MPI.Init()
+rank = MPI.Comm_rank(MPI.COMM_WORLD)
+nprocs = MPI.Comm_size(MPI.COMM_WORLD)
+
+# σ u = -dx²u - dz²u, u(0)=u(1)=0 ⇒ σ_1(k) = k² + π² (Poisson pencil).
+dom = Domain(x = FourierTransformed(), z = Chebyshev(N=24, lower=0.0, upper=1.0))
+prob = EVP(dom, variables=[:u], eigenvalue=:sigma)
+@equation prob sigma * u == -dx(dx(u)) - dz(dz(u))
+@bc prob left(u) == 0
+@bc prob right(u) == 0
+cache = discretize(prob)
+
+ng = (nprocs % 2 == 0) ? 2 : 1
+ks = [0.5, 1.0, 1.5, 2.0]
+
+# Reuse path on a full cache: A/B/eps held across the group's k-subset.
+res = solve(cache, ks; sigma_0=10.0, nev=4, which=:LM, tol=1e-10,
+            ngroups=ng, reuse_factorization=true)
+if rank == 0
+    ts = @testset "reuse_factorization analytic (ngroups=$(ng))" begin
+        @test length(res) == length(ks)
+        for (j, kj) in enumerate(ks)
+            @test res[j].converged
+            σ1 = minimum(real, res[j].eigenvalues)            # smallest = k² + π²
+            @test isapprox(σ1, kj^2 + π^2; rtol=1e-3)
+        end
+        println("reuse ng=$(ng): " *
+                join(["k=$(ks[j]) σ1=$(minimum(real,res[j].eigenvalues))" for j in 1:length(ks)], "  "))
+    end
+    ts.anynonpass && exit(1)
+end
+
+# Reuse path on a per-rank row-restricted (distributed) cache.
+dcache = discretize_distributed(prob; ngroups=ng)
+res_d = solve(dcache, ks; sigma_0=10.0, nev=4, which=:LM, tol=1e-10,
+              ngroups=ng, reuse_factorization=true)
+if rank == 0
+    ts2 = @testset "reuse + distributed cache (ngroups=$(ng))" begin
+        @test length(res_d) == length(ks)
+        for (j, kj) in enumerate(ks)
+            @test res_d[j].converged
+            @test isapprox(minimum(real, res_d[j].eigenvalues), kj^2 + π^2; rtol=1e-3)
+        end
+    end
+    ts2.anynonpass && exit(1)
+end
+
+# Guard: reuse_factorization=true must REJECT a cache with derived-variable terms
+# (augment_derived=false ⇒ non-empty derived_caches ⇒ dense H(k) block not in the union
+# preallocation). The guard runs on every rank before any collective, so a plain try/catch
+# on all ranks is deadlock-safe.
+dom2 = Domain(z = Chebyshev(N=48, lower=0.0, upper=1.0))
+prob2 = EVP(dom2, variables=[:psi], eigenvalue=:sigma)
+@derive prob2 v dz(dz(v)) = psi
+@derive_bc prob2 v left(v) == 0
+@derive_bc prob2 v right(v) == 0
+@equation prob2 sigma * psi == v
+@bc prob2 left(psi) == 0
+@bc prob2 right(psi) == 0
+cache2 = discretize(prob2; augment_derived=false)
+threw = false
+try
+    solve(cache2, [1.0]; sigma_0=-0.1, nev=4, which=:LM, tol=1e-10, reuse_factorization=true)
+catch
+    global threw = true
+end
+if rank == 0
+    ts3 = @testset "reuse guard rejects derived cache" begin
+        @test threw
+    end
+    ts3.anynonpass && exit(1)
+end

--- a/test/test_mpi_prep.jl
+++ b/test/test_mpi_prep.jl
@@ -270,6 +270,50 @@ end
         @test BiGSTARS._keep_by_mass([0.0, 0.0]) == [1, 2]          # all-zero → keep all (fallback)
         @test BiGSTARS._keep_by_mass([1.0, 0.0, 1.0]) == [1, 3]     # exact-zero dropped
     end
+
+    @testset "_union_block_nnz covers every per-k pattern" begin
+        dom = Domain(x=FourierTransformed(), z=Chebyshev(N=12, lower=0.0, upper=1.0))
+        p = EVP(dom, variables=[:u], eigenvalue=:sigma)
+        @equation p sigma * u == -dx(dx(u)) - dz(dz(u))
+        @bc p left(u) == 0; @bc p right(u) == 0
+        cache = discretize(p)
+        N = cache.N_total
+        d, o = BiGSTARS._union_block_nnz(cache.A_components, 0, N, N)
+        @test length(d) == N && length(o) == N
+        @test all(==(0), o)                                   # single rank ⇒ all columns diagonal
+        for k in (0.5, 1.0, 7.0)
+            Ak, _ = BiGSTARS.assemble_rows(cache, k, 0, N)
+            rp, _, _ = BiGSTARS._to_csr(Ak)
+            for r in 1:N
+                @test d[r] + o[r] >= rp[r + 1] - rp[r]        # union ⊇ per-k pattern
+            end
+        end
+        Uref = sum(abs.(M) for M in values(cache.A_components))
+        rpu, _, _ = BiGSTARS._to_csr(Uref)
+        for r in 1:N
+            @test d[r] + o[r] == rpu[r + 1] - rpu[r]          # exactly the OR of all components
+        end
+        # sub-range (multi-rank scenario): exercises the M[rstart+1:rend,:] slice branch and
+        # a partial diagonal column block ⇒ some off-diagonal counts must be nonzero.
+        rs, re = 0, cld(N, 2)
+        ds, os = BiGSTARS._union_block_nnz(cache.A_components, rs, re, N)
+        @test length(ds) == re - rs && length(os) == re - rs
+        @test any(>(0), os)                                   # owned cols [0,N/2) ⇒ remote cols exist
+        for (lr, gr) in enumerate(rs:(re - 1))
+            @test ds[lr] + os[lr] == rpu[gr + 2] - rpu[gr + 1]   # union row nnz, sliced row gr (0-based)
+        end
+    end
+
+    @testset "_eps_options reuse_factorization flag" begin
+        base = BiGSTARS._eps_options(; nev=1, which=:LM, tol=1e-10, maxiter=300, ncv=0,
+                                     mat_solver="mumps", eps_type="krylovschur")
+        @test !occursin("reuse_ordering", base)
+        on = BiGSTARS._eps_options(; nev=1, which=:LM, tol=1e-10, maxiter=300, ncv=0,
+                                   mat_solver="mumps", eps_type="krylovschur",
+                                   reuse_factorization=true)
+        @test occursin("-st_pc_factor_reuse_ordering true", on)
+        @test occursin("-st_pc_factor_reuse_fill true", on)
+    end
 end
 
 @testset "_petsc_ownership matches PETSC_DECIDE split" begin


### PR DESCRIPTION
## Summary
`solve(...; reuse_factorization=true)` holds `A`/`B`/`eps` alive for a group's whole wavenumber subset, refills matrix values in place per k, and reuses the MUMPS LU ordering. Default `false` = unchanged per-k path.

- The operator is **k-dependent** → the *numeric* factorization can't be reused; the *sparsity pattern* is constant across the sweep, so `A`/`B` are preallocated **once** from the union of k-power component patterns (`_union_block_nnz`) and the **symbolic** phase is reused (`-st_pc_factor_reuse_ordering`/`_fill`).
- **Correctness is independent of whether MUMPS actually reuses** — same matrices, same solves; worst case is just per-k object-churn savings.
- Shared `_run_sigma_schedule` DRYs the σ loop across both paths.
- **Guarded** against caches with derived-variable terms (non-empty `derived_caches`, i.e. `augment_derived=false` + `@derive`) whose dense `H(k)` block isn't in the union preallocation → clear error, use the default path.

**Honest framing:** this is a measure-and-maybe-keep experiment. The symbolic-reuse payoff is modest (numeric factorization, the bulk, repeats per k) and whether SLEPc engages it is verifiable only on the cluster. The MPI extension isn't runnable locally — correctness rests on mpi.yml.

## Test Plan
- [x] Pure helpers unit-tested locally: `_union_block_nnz` (union ⊇ every per-k pattern, exact OR-of-components, single-rank + sub-range/off-diagonal cases); `_eps_options` reuse flag on/off.
- [x] Full local suite green (1308/1308); ext parses + package loads; default path unchanged.
- [ ] **mpi.yml** (`test_slepc_reuse.jl`, n=1/2/4): `reuse_factorization=true` matches analytic σ_n = k²+(nπ)² on full + distributed caches; guard rejects a derived cache. **This is the correctness gate for the new PETSc path.**
- [ ] Cluster: measure mean per-k solve time reuse on/off to judge the actual speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)