### PR TITLE
perf: eliminate per-k densification and repeated sparse adds in assembly

### DIFF
--- a/src/discretize.jl
+++ b/src/discretize.jl
@@ -6,6 +6,20 @@
 #  Cache type
 # ──────────────────────────────────────────────────────────────────────────────
 
+"""
+Mutable memo carried by a `DiscretizationCache` so `reconstruct` does not
+rebuild the (eigenvector-independent) inverse operator and RHS matrices for
+every eigenvector. `rhs` is k-independent; `Hk` is keyed by `(field, k)` and
+size-capped because each H(k) is a near-dense N_per_var² matrix.
+"""
+struct ReconstructMemo
+    rhs::Dict{Symbol, Vector{Tuple{Int, KPowerKey, SparseMatrixCSC{ComplexF64, Int}}}}
+    Hk::Dict{Tuple{Symbol, Float64}, SparseMatrixCSC{ComplexF64, Int}}
+end
+ReconstructMemo() = ReconstructMemo(
+    Dict{Symbol, Vector{Tuple{Int, KPowerKey, SparseMatrixCSC{ComplexF64, Int}}}}(),
+    Dict{Tuple{Symbol, Float64}, SparseMatrixCSC{ComplexF64, Int}}())
+
 """Pre-computed info for a derived variable, used to rebuild H(k) during assembly."""
 struct DerivedVarCache
     # The operator matrix WITHOUT the k² term (k-independent part only)
@@ -31,6 +45,9 @@ struct DiscretizationCache
     domain::Domain
     derived_var_order::Vector{Symbol}
     row_range::Union{Nothing, Tuple{Int, Int}}
+    # Memo for `reconstruct`: per-field RHS term matrices (k-independent) and
+    # H(k) per (field, k). H(k) is near-dense, so the H memo is size-capped.
+    reconstruct_memo::ReconstructMemo
 end
 
 const FieldMultiplyCacheKey = Tuple{Symbol, Symbol, Union{Nothing, Symbol}}
@@ -70,7 +87,8 @@ function DiscretizationCache(A_components::Dict{KPowerKey, SparseMatrixCSC{Compl
                              N_total::Int, N_per_var::Int, N_vars::Int, domain::Domain,
                              derived_var_order::Vector{Symbol}=Symbol[])
     return DiscretizationCache(A_components, B_components, derived_caches,
-                               N_total, N_per_var, N_vars, domain, derived_var_order, nothing)
+                               N_total, N_per_var, N_vars, domain, derived_var_order, nothing,
+                               ReconstructMemo())
 end
 
 function _k_coeff(key::KPowerKey, k_vals::Dict{Symbol, Float64})
@@ -193,6 +211,15 @@ function _scatter_block_rows!(buffers::Dict{KPowerKey, _COOBuf}, key::KPowerKey,
                               rstart::Int, rend::Int)
     return _scatter_block_rows!(buffers, key, sparse(ComplexF64.(mat)),
                                 eq_idx, var_idx, N_per_var, rstart, rend)
+end
+
+# Zero (and drop) all stored entries in the given rows — one O(nnz) pass.
+function _zero_sparse_rows!(M::SparseMatrixCSC{ComplexF64, Int}, rows::Set{Int})
+    rv = rowvals(M); vals = nonzeros(M)
+    for idx in eachindex(vals)
+        (rv[idx] in rows) && (vals[idx] = zero(ComplexF64))
+    end
+    return dropzeros!(M)
 end
 
 function _finalize_components(buffers::Dict{KPowerKey, _COOBuf}, nrows::Int, N_total::Int)
@@ -484,9 +511,17 @@ function discretize_expr_in_T(expr::ExprNode, prob::EVP, N_per_var::Int,
                 D_chain_1d = ComplexF64(scale) .* differentiation_operator(p, N) * D_chain_1d
             end
 
-            # D_chain maps T → C^(order). Convert back to T via S^{-1}.
-            S_1d = ComplexF64.(get_conversion_operator(domain, coord, 0, order))
-            S_inv_1d = sparse(Matrix(S_1d) \ Matrix(ComplexF64(1.0) * I(N)))
+            # D_chain maps T → C^(order). Convert back to T via S^{-1}
+            # (memoized per order on the build context — dense O(N³) solve).
+            S_inv_1d = if !isnothing(ctx)
+                get!(ctx.sinv_1d_cache, order) do
+                    S_1d = ComplexF64.(get_conversion_operator(domain, coord, 0, order))
+                    sparse(Matrix(S_1d) \ Matrix(ComplexF64(1.0) * I, N, N))
+                end
+            else
+                S_1d = ComplexF64.(get_conversion_operator(domain, coord, 0, order))
+                sparse(Matrix(S_1d) \ Matrix(ComplexF64(1.0) * I, N, N))
+            end
 
             # Lift the combined 1D operator to full grid (Kronecker product)
             op_1d = S_inv_1d * D_chain_1d
@@ -552,10 +587,7 @@ function _build_2d_field_multiply(f_vec::AbstractVector, domain::Domain,
     f_physical = reshape(Float64.(f_vec), N_z, N_y)
 
     # FFT along y for each z-point → f_hat[iz, m] (complex Fourier coefficients)
-    f_hat = zeros(ComplexF64, N_z, N_y)
-    for iz in 1:N_z
-        f_hat[iz, :] = fft(f_physical[iz, :]) / N_y
-    end
+    f_hat = fft(f_physical, 2) ./ N_y
 
     # For each Fourier mode shift Δm, compute Chebyshev coefficients of f̂_Δm(z)
     # and build M_z(f̂_Δm) — the N_z × N_z Chebyshev multiplication operator
@@ -589,10 +621,7 @@ function _build_2d_field_multiply_banded(f_vec::AbstractVector, domain::Domain,
     N_y = domain.coords[fourier_dim].N
 
     f_physical = reshape(Float64.(f_vec), N_z, N_y)
-    f_hat = zeros(ComplexF64, N_z, N_y)
-    for iz in 1:N_z
-        f_hat[iz, :] = fft(f_physical[iz, :]) / N_y
-    end
+    f_hat = fft(f_physical, 2) ./ N_y
 
     Mz_blocks = Vector{SparseMatrixCSC{ComplexF64, Int}}(undef, N_y)
     for dm in 0:N_y-1
@@ -1050,20 +1079,22 @@ function _sparse_block_inverse(op::AbstractMatrix, domain::Domain;
     N_y = domain.coords[fourier_dim].N
     @assert N_y * N_z == N
 
-    # Check if operator is block-diagonal (each N_z × N_z block is independent)
+    # Check if operator is block-diagonal (each N_z × N_z block is independent).
+    # Accumulate per-block ‖·‖² directly from the sparse structure — O(nnz),
+    # no densification of the full operator.
+    op_sp = op isa SparseMatrixCSC{ComplexF64, Int} ? op : sparse(ComplexF64.(op))
     is_block_diag = true
-    op_dense = Matrix(op)
-    for m1 in 0:N_y-1
-        for m2 in 0:N_y-1
-            m1 == m2 && continue
-            rs = m1 * N_z + 1; re = rs + N_z - 1
-            cs = m2 * N_z + 1; ce = cs + N_z - 1
-            if norm(op_dense[rs:re, cs:ce]) > 1e-12
-                is_block_diag = false
-                break
+    let rows = rowvals(op_sp), vals = nonzeros(op_sp), tol2 = 1e-12^2
+        offnorm2 = zeros(Float64, N_y, N_y)
+        for col in 1:N
+            m2 = (col - 1) ÷ N_z + 1
+            for idx in nzrange(op_sp, col)
+                m1 = (rows[idx] - 1) ÷ N_z + 1
+                m1 == m2 && continue
+                offnorm2[m1, m2] += abs2(vals[idx])
             end
         end
-        is_block_diag || break
+        is_block_diag = all(<=(tol2), offnorm2)
     end
 
     # Build BC rows for boundary bordering (if any)
@@ -1079,11 +1110,18 @@ function _sparse_block_inverse(op::AbstractMatrix, domain::Domain;
     end
 
     if is_block_diag
-        H = spzeros(ComplexF64, N, N)
+        block = Matrix{ComplexF64}(undef, N_z, N_z)  # reused dense buffer
+        rows = rowvals(op_sp); vals = nonzeros(op_sp)
+        H_blocks = Vector{SparseMatrixCSC{ComplexF64, Int}}(undef, N_y)
+        zero_block = spzeros(ComplexF64, N_z, N_z)
         for m in 0:N_y-1
             rs = m * N_z + 1
-            re = rs + N_z - 1
-            block = copy(op_dense[rs:re, rs:re])
+            fill!(block, zero(ComplexF64))
+            for col in rs:rs+N_z-1
+                for idx in nzrange(op_sp, col)
+                    block[rows[idx] - rs + 1, col - rs + 1] = vals[idx]
+                end
+            end
 
             # Apply boundary bordering: replace last rows with BC rows
             for (i, bc_row) in enumerate(bc_rows_1d)
@@ -1091,15 +1129,19 @@ function _sparse_block_inverse(op::AbstractMatrix, domain::Domain;
                 block[row_idx, :] = ComplexF64.(bc_row)
             end
 
-            if abs(det(block)) < 1e-14
-                continue  # still singular after BCs → skip (e.g., m=0 at k=0)
+            # One LU does both the singularity test (via det of the factors,
+            # matching the old abs(det) < 1e-14 skip) and the inverse.
+            F = lu!(block, check=false)
+            if !issuccess(F) || abs(det(F)) < 1e-14
+                H_blocks[m + 1] = zero_block  # still singular after BCs (e.g., m=0 at k=0)
+                continue
             end
-            H[rs:re, rs:re] = sparse(block \ Matrix(ComplexF64(1.0) * I, N_z, N_z))
+            H_blocks[m + 1] = sparse(inv(F))
         end
-        return H
+        return blockdiag(H_blocks...)
     else
         # Non-block-diagonal: fall back to dense inverse
-        return sparse(op_dense \ Matrix(ComplexF64(1.0) * I, N, N))
+        return sparse(Matrix(op_sp) \ Matrix(ComplexF64(1.0) * I, N, N))
     end
 end
 
@@ -1125,9 +1167,17 @@ function _discretize_operator(expr::ExprNode, dummy::Union{Symbol,Nothing}, prob
             for p in 0:order-1
                 D_chain_1d = ComplexF64(scale) .* differentiation_operator(p, N_z) * D_chain_1d
             end
-            # D_chain maps T→C^(order). Convert back to T with S^{-1}:
-            S_1d = ComplexF64.(get_conversion_operator(domain, coord, 0, order))
-            S_inv_1d = sparse(Matrix(S_1d) \ Matrix(ComplexF64(1.0) * I, N_z, N_z))
+            # D_chain maps T→C^(order). Convert back to T with S^{-1}
+            # (memoized per order on the build context — dense O(N³) solve):
+            S_inv_1d = if !isnothing(ctx)
+                get!(ctx.sinv_1d_cache, order) do
+                    S_1d = ComplexF64.(get_conversion_operator(domain, coord, 0, order))
+                    sparse(Matrix(S_1d) \ Matrix(ComplexF64(1.0) * I, N_z, N_z))
+                end
+            else
+                S_1d = ComplexF64.(get_conversion_operator(domain, coord, 0, order))
+                sparse(Matrix(S_1d) \ Matrix(ComplexF64(1.0) * I, N_z, N_z))
+            end
             D_T_1d = S_inv_1d * D_chain_1d  # T→T derivative operator
             D_full = _lift_to_2d(D_T_1d, coord, domain)
             return D_full * _discretize_operator(inner, dummy, prob, N_per_var, ctx)
@@ -1790,7 +1840,6 @@ function discretize(prob::EVP; augment_derived::Bool=true,
     # and k² coefficient (-1 from dx²). H(k) = (op_k0 + k² * coeff * I)^{-1}
     # is recomputed per-wavenumber during assemble.
     derived_caches = Dict{Symbol, DerivedVarCache}()
-    derived_H_k0 = Dict{Symbol, AbstractMatrix}()  # H at k=0 for discretize-time use
 
     for (dname, dvar) in prob.derived_vars
         op_expr = expand_substitutions(
@@ -1822,8 +1871,6 @@ function discretize(prob::EVP; augment_derived::Bool=true,
             end
         end
 
-        H_k0 = _sparse_block_inverse(op_k0, prob.domain; bcs=dvar.bcs)
-        derived_H_k0[dname] = H_k0
         derived_caches[dname] = DerivedVarCache(op_k0, op_k2_coeff, op_k_components, dvar.bcs,
             Tuple{Int, Int, KPowerKey, SparseMatrixCSC{ComplexF64, Int}, SparseMatrixCSC{ComplexF64, Int}}[])
     end
@@ -1927,26 +1974,29 @@ function discretize(prob::EVP; augment_derived::Bool=true,
         end
     end
 
-    # Collect all BC row indices for zeroing
-    bc_row_indices = unique([row_idx for (row_idx, _, _, _) in bc_info])
-
-    # First, zero out owned BC rows in ALL k-power components (both A and B).
-    for p in keys(A_components)
-        for row_idx in bc_row_indices
-            lr = row_idx - rstart
-            (1 <= lr <= nrows) || continue
-            A_components[p][lr, :] .= zero(ComplexF64)
-        end
-    end
-    for p in keys(B_components)
-        for row_idx in bc_row_indices
-            lr = row_idx - rstart
-            (1 <= lr <= nrows) || continue
-            B_components[p][lr, :] .= zero(ComplexF64)
-        end
+    # Collect owned BC rows (local indices) for zeroing
+    owned_bc_rows = Set{Int}()
+    for (row_idx, _, _, _) in bc_info
+        lr = row_idx - rstart
+        (1 <= lr <= nrows) && push!(owned_bc_rows, lr)
     end
 
-    # Then write owned BC rows into the correct k-power components.
+    # First, zero out owned BC rows in ALL k-power components (both A and B) —
+    # one O(nnz) pass per component instead of a sparse row-assignment per row.
+    if !isempty(owned_bc_rows)
+        for p in keys(A_components)
+            _zero_sparse_rows!(A_components[p], owned_bc_rows)
+        end
+        for p in keys(B_components)
+            _zero_sparse_rows!(B_components[p], owned_bc_rows)
+        end
+    end
+
+    # Then write owned BC rows into the correct k-power components: gather all BC
+    # entries per key as COO triplets and add each key's sparse matrix once
+    # (element-wise sparse `+=` is an O(nnz) insertion per entry).
+    bc_bufA = Dict{KPowerKey, _COOBuf}()
+    bc_bufB = Dict{KPowerKey, _COOBuf}()
     for (row_idx, kp, a_row, b_row) in bc_info
         # Register the BC's k-power key in BOTH A and B regardless of row ownership, so a
         # restricted cache has the same key set as the full build (mirrors restrict_cache_rows,
@@ -1961,17 +2011,27 @@ function discretize(prob::EVP; augment_derived::Bool=true,
         end
         lr = row_idx - rstart
         (1 <= lr <= nrows) || continue
+        Ia, Ja, Va = get!(() -> (Int[], Int[], ComplexF64[]), bc_bufA, kp)
         for (j, v) in enumerate(a_row)
-            v != 0.0 && (A_components[kp][lr, j] += ComplexF64(v))
+            v != 0.0 && (push!(Ia, lr); push!(Ja, j); push!(Va, ComplexF64(v)))
         end
+        Ib, Jb, Vb = get!(() -> (Int[], Int[], ComplexF64[]), bc_bufB, kp)
         for (j, v) in enumerate(b_row)
-            v != 0.0 && (B_components[kp][lr, j] += ComplexF64(v))
+            v != 0.0 && (push!(Ib, lr); push!(Jb, j); push!(Vb, ComplexF64(v)))
         end
+    end
+    for (kp, (Ia, Ja, Va)) in bc_bufA
+        isempty(Va) && continue
+        A_components[kp] = A_components[kp] + sparse(Ia, Ja, Va, nrows, N_total)
+    end
+    for (kp, (Ib, Jb, Vb)) in bc_bufB
+        isempty(Vb) && continue
+        B_components[kp] = B_components[kp] + sparse(Ib, Jb, Vb, nrows, N_total)
     end
 
     return DiscretizationCache(A_components, B_components, derived_caches,
                                N_total, N_per_var, N_vars, prob.domain,
-                               derived_var_order, row_range)
+                               derived_var_order, row_range, ReconstructMemo())
 end
 
 """
@@ -2048,33 +2108,52 @@ function assemble(cache::DiscretizationCache, k::Float64)
     return _assemble(cache, _k_values(cache, k))
 end
 
+# Append the scaled triplets of every k-power component to (I, J, V). The final
+# `sparse(I, J, V, ...)` sums duplicates — identical to the old repeated sparse `+`,
+# without allocating a fresh full-size accumulator per component.
+function _append_component_triplets!(I::Vector{Int}, J::Vector{Int}, V::Vector{ComplexF64},
+                                     components::Dict{KPowerKey, SparseMatrixCSC{ComplexF64, Int}},
+                                     k_vals::Dict{Symbol, Float64})
+    total = 0
+    for (kp, M) in components
+        _k_coeff(kp, k_vals) == 0.0 && continue
+        total += nnz(M)
+    end
+    sizehint!(I, length(I) + total)
+    sizehint!(J, length(J) + total)
+    sizehint!(V, length(V) + total)
+    for (kp, M) in components
+        c = _k_coeff(kp, k_vals)
+        c == 0.0 && continue
+        rows = rowvals(M); vals = nonzeros(M)
+        for col in 1:size(M, 2)
+            for idx in nzrange(M, col)
+                push!(I, rows[idx])
+                push!(J, col)
+                push!(V, c == 1.0 ? vals[idx] : c * vals[idx])
+            end
+        end
+    end
+    return nothing
+end
+
 function _assemble(cache::DiscretizationCache, k_vals::Dict{Symbol, Float64})
     cache.row_range === nothing ||
         throw(ArgumentError("assemble needs a full (unrestricted) cache; got " *
             "row_range=$(cache.row_range). Its components are row-sliced — " *
             "use assemble_rows(cache, k, rstart, rend) instead."))
     N = cache.N_total
-    A = spzeros(ComplexF64, N, N)
-    for (kp, Ap) in cache.A_components
-        coeff = _k_coeff(kp, k_vals)
-        if coeff == 1.0
-            A = A + Ap
-        else
-            A = A + coeff * Ap
-        end
-    end
+    N_per_var = cache.N_per_var
 
-    B = spzeros(ComplexF64, N, N)
-    for (kp, Bp) in cache.B_components
-        coeff = _k_coeff(kp, k_vals)
-        if coeff == 1.0
-            B = B + Bp
-        else
-            B = B + coeff * Bp
-        end
-    end
+    AI = Int[]; AJ = Int[]; AV = ComplexF64[]
+    _append_component_triplets!(AI, AJ, AV, cache.A_components, k_vals)
 
-    # Apply derived variable terms with k-dependent H(k)
+    BI = Int[]; BJ = Int[]; BV = ComplexF64[]
+    _append_component_triplets!(BI, BJ, BV, cache.B_components, k_vals)
+    B = sparse(BI, BJ, BV, N, N)
+
+    # Apply derived variable terms with k-dependent H(k), scattered straight into
+    # the COO buffers (no full-size place_in_block temporary per term).
     for (dname, dc) in cache.derived_caches
         isempty(dc.terms) && continue
 
@@ -2088,12 +2167,23 @@ function _assemble(cache::DiscretizationCache, k_vals::Dict{Symbol, Float64})
         H_k = _sparse_block_inverse(op_k, cache.domain; bcs=dc.bcs)
 
         for (eq_idx, var_idx, total_kp, coeff_mat, rhs_mat) in dc.terms
+            w = _k_coeff(total_kp, k_vals)
+            w == 0.0 && continue
             combined = coeff_mat * H_k * rhs_mat
-            block = place_in_block(combined, eq_idx, var_idx, cache.N_vars, cache.N_per_var)
-            A = A + _k_coeff(total_kp, k_vals) * block
+            row_off = (eq_idx - 1) * N_per_var
+            col_off = (var_idx - 1) * N_per_var
+            rows = rowvals(combined); vals = nonzeros(combined)
+            for col in 1:size(combined, 2)
+                for idx in nzrange(combined, col)
+                    push!(AI, rows[idx] + row_off)
+                    push!(AJ, col + col_off)
+                    push!(AV, w * vals[idx])
+                end
+            end
         end
     end
 
+    A = sparse(AI, AJ, AV, N, N)
     return A, B
 end
 

--- a/src/mpi_prep.jl
+++ b/src/mpi_prep.jl
@@ -15,11 +15,10 @@ into CSC of `Aᵀ`, whose column storage is exactly the row storage of `A`, so t
 per-row column indices come out sorted and contiguous.
 """
 function _to_csr(A::SparseMatrixCSC)
-    At = sparse(transpose(A))          # CSC of Aᵀ == CSR of A
+    At = sparse(transpose(A))          # CSC of Aᵀ == CSR of A; fresh, so no copies needed
     rowptr = Int32.(At.colptr .- 1)    # 0-based
     colind = Int32.(At.rowval .- 1)    # 0-based column indices
-    vals = copy(At.nzval)
-    return rowptr, colind, vals
+    return rowptr, colind, At.nzval
 end
 
 """
@@ -227,13 +226,10 @@ for the singular-`B` mode filter. Pure-Julia (no PETSc), so it is CI-testable.
 function sparse_from_csr(csr)
     rowptr, colind, vals = csr
     N = length(rowptr) - 1
-    I = Int[]; J = Int[]; V = eltype(vals)[]
-    for r in 1:N
-        for k in (rowptr[r] + 1):rowptr[r + 1]
-            push!(I, r); push!(J, colind[k] + 1); push!(V, vals[k])
-        end
-    end
-    return sparse(I, J, V, N, N)
+    # The CSR arrays are exactly the CSC storage of the transpose (indices are
+    # sorted within each row by construction) — rebuild directly, no COO re-sort.
+    At = SparseMatrixCSC(N, N, Int.(rowptr) .+ 1, Int.(colind) .+ 1, Vector(vals))
+    return sparse(transpose(At))
 end
 
 """
@@ -288,7 +284,8 @@ function restrict_cache_rows(cache, rstart::Integer, rend::Integer)
     end
     return DiscretizationCache(_slice_rows(cache.A_components), _slice_rows(cache.B_components),
         cache.derived_caches, cache.N_total, cache.N_per_var, cache.N_vars,
-        cache.domain, cache.derived_var_order, (Int(rstart), Int(rend)))
+        cache.domain, cache.derived_var_order, (Int(rstart), Int(rend)),
+        ReconstructMemo())
 end
 
 """
@@ -313,21 +310,45 @@ function assemble_rows(cache, k::Float64,
     sliced = cache.row_range === nothing          # full cache → slice; restricted → use as-is
     k_vals = _k_values(cache, k)
     nrows = rend - rstart
+    N_per_var = cache.N_per_var
 
-    A_rows = spzeros(ComplexF64, nrows, N)
-    for (kp, Ap) in cache.A_components
-        c = _k_coeff(kp, k_vals); c == 0.0 && continue
-        A_rows = A_rows + c * (sliced ? Ap[(rstart + 1):rend, :] : Ap)
+    # Accumulate scaled COO triplets per pencil and build each with ONE sparse()
+    # call (duplicates summed), instead of a fresh full-size sparse `+` per
+    # component. With a full cache the row restriction happens during the
+    # triplet walk — no intermediate row-slice matrix is materialized.
+    function _gather(components)
+        I = Int[]; J = Int[]; V = ComplexF64[]
+        for (kp, M) in components
+            c = _k_coeff(kp, k_vals); c == 0.0 && continue
+            rows = rowvals(M); vals = nonzeros(M)
+            for col in 1:size(M, 2)
+                for idx in nzrange(M, col)
+                    g = rows[idx]
+                    if sliced
+                        (rstart < g <= rend) || continue
+                        push!(I, g - rstart)
+                    else
+                        push!(I, g)
+                    end
+                    push!(J, col)
+                    push!(V, c == 1.0 ? vals[idx] : c * vals[idx])
+                end
+            end
+        end
+        return sparse(I, J, V, nrows, N)
     end
+    A_rows = _gather(cache.A_components)
+    B_rows = _gather(cache.B_components)
 
-    B_rows = spzeros(ComplexF64, nrows, N)
-    for (kp, Bp) in cache.B_components
-        c = _k_coeff(kp, k_vals); c == 0.0 && continue
-        B_rows = B_rows + c * (sliced ? Bp[(rstart + 1):rend, :] : Bp)
-    end
-
+    AI = Int[]; AJ = Int[]; AV = ComplexF64[]
     for (_, dc) in cache.derived_caches
         isempty(dc.terms) && continue
+        # Skip H(k) entirely (block inverses — the dominant cost) when none of this
+        # derived variable's equation row-blocks intersect the owned slice.
+        any(dc.terms) do (eq_idx, _, total_kp, _, _)
+            bs = (eq_idx - 1) * N_per_var
+            max(bs, rstart) < min(bs + N_per_var, rend) && _k_coeff(total_kp, k_vals) != 0.0
+        end || continue
         op_k = dc.op_k0
         for (kp, mat) in dc.op_k_components
             c = _k_coeff(kp, k_vals); c == 0.0 && continue
@@ -336,11 +357,27 @@ function assemble_rows(cache, k::Float64,
         H_k = _sparse_block_inverse(op_k, cache.domain; bcs=dc.bcs)
         for (eq_idx, var_idx, total_kp, coeff_mat, rhs_mat) in dc.terms
             w = _k_coeff(total_kp, k_vals); w == 0.0 && continue
-            combined = coeff_mat * H_k * rhs_mat
-            A_rows = A_rows + w * _place_in_block_rows(combined, eq_idx, var_idx,
-                                                       cache.N_per_var, cache.N_vars,
-                                                       rstart, rend)
+            # Restrict to the owned rows BEFORE the triple product: only the owned
+            # slice of coeff_mat enters, so per-rank work/memory for derived terms
+            # scales with the owned row count, not the full block size.
+            bs = (eq_idx - 1) * N_per_var
+            lo = max(bs, rstart); hi = min(bs + N_per_var, rend)
+            lo < hi || continue
+            combined = (coeff_mat[(lo - bs + 1):(hi - bs), :] * H_k) * rhs_mat
+            row_off = lo - rstart
+            col_off = (var_idx - 1) * N_per_var
+            rows = rowvals(combined); vals = nonzeros(combined)
+            for col in 1:size(combined, 2)
+                for idx in nzrange(combined, col)
+                    push!(AI, rows[idx] + row_off)
+                    push!(AJ, col + col_off)
+                    push!(AV, w * vals[idx])
+                end
+            end
         end
+    end
+    if !isempty(AV)
+        A_rows = A_rows + sparse(AI, AJ, AV, nrows, N)
     end
     return A_rows, B_rows
 end
@@ -358,10 +395,7 @@ function _assemble_B_full(cache, k::Float64)
             "row_range=$(cache.row_range). Its B_components are row-sliced — use assemble_rows."))
     k_vals = _k_values(cache, k)
     N = cache.N_total
-    B = spzeros(ComplexF64, N, N)
-    for (kp, Bp) in cache.B_components
-        c = _k_coeff(kp, k_vals); c == 0.0 && continue
-        B = B + c * Bp
-    end
-    return B
+    I = Int[]; J = Int[]; V = ComplexF64[]
+    _append_component_triplets!(I, J, V, cache.B_components, k_vals)
+    return sparse(I, J, V, N, N)
 end

--- a/src/reconstruct.jl
+++ b/src/reconstruct.jl
@@ -97,7 +97,7 @@ function _evaluate_expr(expr::ExprNode, prob::EVP, cache::DiscretizationCache,
         if expr.name in prob.variables
             var_idx = findfirst(==(expr.name), prob.variables)
             start = (var_idx - 1) * N_per_var + 1
-            return ComplexF64.(eigvec[start:start+N_per_var-1])
+            return ComplexF64.(@view eigvec[start:start+N_per_var-1])
         elseif haskey(prob.derived_vars, expr.name)
             # Derived variable: reconstruct via inverse operator
             return reconstruct(cache, prob, eigvec, k, expr.name)
@@ -251,7 +251,7 @@ function reconstruct(cache::DiscretizationCache, prob::EVP,
         n_real = cache.N_vars - length(cache.derived_var_order)
         di = findfirst(==(field_name), cache.derived_var_order)
         blk = (n_real + di - 1) * cache.N_per_var
-        return ComplexF64.(eigvec[blk+1 : blk + cache.N_per_var])
+        return ComplexF64.(@view eigvec[blk+1 : blk + cache.N_per_var])
     end
 
     haskey(prob.derived_vars, field_name) ||
@@ -270,32 +270,46 @@ function reconstruct(cache::DiscretizationCache, prob::EVP,
         end
     end
 
-    # Build H(k) for this wavenumber
-    op_k = dc.op_k0
-    for (kp, mat) in dc.op_k_components
-        coeff = _k_coeff(kp, k_vals)
-        coeff == 0.0 && continue
-        op_k = op_k + coeff * mat
+    # H(k) and the discretized RHS term matrices depend only on (field, k) — not
+    # on the eigenvector. Memoize them on the cache so reconstructing many
+    # eigenvectors (reconstruct_all, evaluate_field) pays the block inverses and
+    # the DSL lowering once per (field, k) instead of once per eigenvector.
+    memo = cache.reconstruct_memo
+    H_k = get!(memo.Hk, (field_name, k)) do
+        # H(k) is near-dense (N_per_var²); cap the memo so a k-sweep can't hoard memory.
+        length(memo.Hk) >= 8 && empty!(memo.Hk)
+        op_k = dc.op_k0
+        for (kp, mat) in dc.op_k_components
+            coeff = _k_coeff(kp, k_vals)
+            coeff == 0.0 && continue
+            op_k = op_k + coeff * mat
+        end
+        _sparse_block_inverse(op_k, cache.domain; bcs=dc.bcs)
     end
-    H_k = _sparse_block_inverse(op_k, cache.domain; bcs=dc.bcs)
 
-    # Expand and lower the RHS expression
-    rhs_expanded = expand_substitutions(dvar.rhs, prob.substitutions)
-    rhs_lowered = lower_derivatives(rhs_expanded, prob.domain)
-    rhs_distributed = distribute_products(rhs_lowered)
-    rhs_additive = separate_additive_terms(rhs_distributed)
+    # Expand, lower, and discretize the RHS terms (k-independent) — memoized per field.
+    rhs_terms = get!(memo.rhs, field_name) do
+        rhs_expanded = expand_substitutions(dvar.rhs, prob.substitutions)
+        rhs_lowered = lower_derivatives(rhs_expanded, prob.domain)
+        rhs_distributed = distribute_products(rhs_lowered)
+        rhs_additive = separate_additive_terms(rhs_distributed)
+        terms = Tuple{Int, KPowerKey, SparseMatrixCSC{ComplexF64, Int}}[]
+        for rhs_term in rhs_additive
+            rhs_k_powers, rhs_reduced = extract_k_powers(rhs_term)
+            rhs_mat = _discretize_operator(rhs_reduced, nothing, prob, N_per_var)
+            var_idx = find_target_variable(rhs_reduced, prob.variables)
+            push!(terms, (var_idx, rhs_k_powers, sparse(ComplexF64.(rhs_mat))))
+        end
+        terms
+    end
 
     # Accumulate: result = H(k) * Σ (prod(k_i^p_i) * rhs_op * var_coeffs)
     rhs_vec = zeros(ComplexF64, N_per_var)
 
-    for rhs_term in rhs_additive
-        rhs_k_powers, rhs_reduced = extract_k_powers(rhs_term)
-        rhs_mat = _discretize_operator(rhs_reduced, nothing, prob, N_per_var)
-        var_idx = find_target_variable(rhs_reduced, prob.variables)
-
+    for (var_idx, rhs_k_powers, rhs_mat) in rhs_terms
         # Extract this variable's coefficients from the eigenvector
         var_start = (var_idx - 1) * N_per_var + 1
-        var_coeffs = eigvec[var_start:var_start+N_per_var-1]
+        var_coeffs = @view eigvec[var_start:var_start+N_per_var-1]
 
         rhs_vec .+= _k_coeff(rhs_k_powers, k_vals) .* (rhs_mat * var_coeffs)
     end

--- a/src/results.jl
+++ b/src/results.jl
@@ -75,10 +75,10 @@ back to the inputs), so callers always get a usable result.
 """
 function _filter_physical_modes(λ::AbstractVector, Χ::AbstractMatrix, B; rtol::Float64=1e-6)
     (isempty(λ) || size(Χ, 2) == 0) && return λ, Χ
+    BX = B * Χ   # one sparse×dense product instead of a mat-vec (+ temp) per mode
     masses = Vector{Float64}(undef, size(Χ, 2))
     @inbounds for i in 1:size(Χ, 2)
-        χ = view(Χ, :, i)
-        masses[i] = norm(B * χ) / max(norm(χ), eps())   # norm(χ) computed once
+        masses[i] = norm(view(BX, :, i)) / max(norm(view(Χ, :, i)), eps())
     end
     scale = maximum(masses)
     scale == 0.0 && return λ, Χ

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -14,7 +14,7 @@ function chebyshev_evaluate(c::AbstractVector, x::AbstractVector)
     N = length(c)
     T = promote_type(eltype(c), eltype(x), Float64)
     result = similar(x, T)
-    for (i, xi) in enumerate(x)
+    @inbounds for (i, xi) in enumerate(x)
         # Clenshaw recurrence for T polynomials
         b_kp1 = zero(T)
         b_kp2 = zero(T)
@@ -82,26 +82,28 @@ function differentiate(f::AbstractVector, domain::Domain, coord::Symbol;
 
         scale = 2.0 / (spec.upper - spec.lower)
 
-        # Physical values → T coefficients
+        # Physical values → T coefficients (conversion handled inside)
         x_ref = chebyshev_points(N)
-        c = chebyshev_coefficients(Float64.(f))
+        dc = chebyshev_coefficients(f)
 
         # Apply differentiation chain: D_{order-1} * ⋯ * D_0 (each scaled)
-        dc = Float64.(c)
         for p in 0:order-1
             D = differentiation_operator(p, N)
             dc = scale .* (D * dc)
         end
 
-        # dc is now in C^(order) basis — convert back to T via S_{0→order}^{-1}
+        # dc is now in C^(order) basis — convert back to T via S_{0→order}^{-1}.
+        # S is upper triangular (bandwidth 2·order): back-substitution, no dense LU.
         S = get_conversion_operator(domain, coord, 0, order)
-        c_T = Matrix(S) \ dc
+        c_T = UpperTriangular(S) \ dc
         return chebyshev_evaluate(c_T, x_ref)
 
     elseif spec isa FourierBasisSpec
         N = spec.N
         @assert length(f) == N "Input length ($(length(f))) must match grid size ($N)"
-        f_hat = fft(f) / N
+        # No 1/N–N normalization pair: fft/ifft are already inverses and the
+        # diagonal derivative operator is scale-free.
+        f_hat = fft(f)
 
         # Apply spectral filter before differentiation
         if filter !== :none
@@ -112,8 +114,7 @@ function differentiate(f::AbstractVector, domain::Domain, coord::Symbol;
         end
 
         D = fourier_diff_operator(N, spec.L, order)
-        df_hat = D * f_hat
-        result = ifft(df_hat * N)
+        result = ifft(D * f_hat)
         # Real input → real derivative (drop FFT round-off imag). Complex input
         # (e.g. a reconstructed eigenfunction) → keep the full complex derivative.
         return eltype(f) <: Real ? real.(result) : result

--- a/src/ultraspherical.jl
+++ b/src/ultraspherical.jl
@@ -151,22 +151,26 @@ function multiplication_operator(f_coeffs::AbstractVector, N::Int; tol::Float64=
     # Pad or truncate f_coeffs to work with
     nf = length(f_coeffs)
 
+    # Hoist the tolerance filter out of the O(N·nf) loop and fix the eltype.
+    nzc = Tuple{Int, Float64}[]
+    for k in 1:nf
+        fk = f_coeffs[k]
+        abs(fk) < tol && continue
+        push!(nzc, (k - 1, Float64(fk)))
+    end
+
     rows = Int[]
     cols = Int[]
     vals = Float64[]
+    sizehint!(rows, 2 * N * length(nzc))
+    sizehint!(cols, 2 * N * length(nzc))
+    sizehint!(vals, 2 * N * length(nzc))
 
     # Column j corresponds to multiplication by T_{j-1}
     for j in 1:N
         n = j - 1  # T_n index (0-based)
 
-        for k in 1:nf
-            m = k - 1  # f coefficient index (0-based), coefficient f_coeffs[k]
-            fk = f_coeffs[k]
-
-            if abs(fk) < tol
-                continue
-            end
-
+        for (m, fk) in nzc
             # T_m * T_n = (T_{|m-n|} + T_{m+n}) / 2
             # Contribution to row |m-n|+1 and row m+n+1
 
@@ -262,14 +266,18 @@ function ultraspherical_multiplication_operator(f_coeffs::AbstractVector, N::Int
         M = M + a[2] * T_cur
         for m in 3:d
             T_next = 2 * (J * T_cur) - T_prev
-            M = M + a[m] * T_next
+            # The recurrence must still advance for interior near-zero
+            # coefficients, but their axpy into M can be skipped.
+            if abs(a[m]) > tol
+                M = M + a[m] * T_next
+            end
             T_prev = T_cur
             T_cur  = T_next
             droptol!(T_cur, tol)
         end
     end
 
-    Msl = sparse(M[1:N, 1:N])
+    Msl = M[1:N, 1:N]   # sparse slice already returns a fresh SparseMatrixCSC
     droptol!(Msl, tol)
     return Msl
 end
@@ -322,6 +330,16 @@ where '' means the first and last terms are halved.
 
 The returned vector has length N, where c[k] is the coefficient of T_{k-1}.
 """
+# Memoized DCT-I plans per length: FFTW.r2r without a plan re-plans the
+# transform on every call, and this runs O(N_y) times per y-varying field.
+const _dct1_plan_cache = Dict{Int, FFTW.r2rFFTWPlan{Float64}}()
+
+function _dct1_plan(N::Int)
+    return get!(_dct1_plan_cache, N) do
+        FFTW.plan_r2r(Vector{Float64}(undef, N), FFTW.REDFT00)
+    end
+end
+
 function chebyshev_coefficients(f_values::AbstractVector)
     N = length(f_values)
     @assert N >= 2 "Need at least 2 values"
@@ -332,9 +350,10 @@ function chebyshev_coefficients(f_values::AbstractVector)
     # The Chebyshev coefficient c_k (double-prime sum) satisfies:
     #   c_k = Y_k / (N-1), with c_0 and c_{N-1} halved.
     n = N - 1
-    Y = FFTW.r2r(Float64.(f_values), FFTW.REDFT00)
+    x = f_values isa Vector{Float64} ? f_values : Float64.(f_values)
+    coeffs = _dct1_plan(N) * x   # out-of-place: x is not mutated
 
-    coeffs = Y ./ n
+    coeffs ./= n
     coeffs[1] /= 2.0
     coeffs[N] /= 2.0
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,11 +43,7 @@ end
 """
 function sort_evals(λs::AbstractVector, χ::AbstractMatrix, which::String; sorting::String="lm")
     @assert which in ("M", "I", "R")
-    by_func = Dict(
-        "M" => abs,
-        "I" => imag,
-        "R" => real
-    )[which]
+    by_func = which == "M" ? abs : which == "I" ? imag : real
 
     idx = sortperm(λs, by=by_func, rev=(sorting == "lm"))
     return λs[idx], χ[:, idx]
@@ -81,18 +77,9 @@ function remove_evals(λs, χ, lower, higher, which)
 
     @assert which ∈ ["M", "I", "R"]
 
-    if which == "I" # imaginary part
-        arg = findall( (lower .≤ imag(λs)) .& (imag(λs) .≤ higher) )
-    end
+    f = which == "I" ? imag : which == "R" ? real : abs
+    arg = findall(λ -> lower ≤ f(λ) ≤ higher, λs)
 
-    if which == "R" # real part
-        arg = findall( (lower .≤ real(λs)) .& (real(λs) .≤ higher) )
-    end
-    
-    if which == "M" # absolute magnitude
-        arg = findall( (lower .≤ abs.(λs)) .& (abs.(λs) .≤ higher) )
-    end
-    
     χ  = χ[:,arg]
     λs = λs[arg]
 


### PR DESCRIPTION
## Summary

Allocation/type-stability pass over the assembly, reconstruction, and transform hot paths. Behavior-preserving: assembled pencils and reconstructed fields are **bit-identical** (sum, nnz, field-norm fingerprints) on the polar-vortex benchmark before/after.

**Measured** (polar-vortex shape: 5 vars + 4 derived vars, `Nx=180`, `Nz=30`, A/B on the same machine):

| | before | after |
|---|---|---|
| `discretize` | 122.9 s | **6.7 s (18×)** |
| `assemble` ×2 wavenumbers | 3.4 s / 6.6 GB alloc | **2.4 s / 5.1 GB** |

## Hot path (per wavenumber)

- **`_sparse_block_inverse`**: block-diagonality checked on the sparse structure in O(nnz) — previously `Matrix(op)` densified the full operator per k just to run the check, plus un-viewed block slices. Block inversion now does **one** `lu!` per block (the old `abs(det(block)) < 1e-14` ran a full LU for `det`, then a second for `\`; the det is now taken from the same factors, so skip semantics are unchanged), assembled with `blockdiag` instead of sparse range-setindex.
- **`_assemble` / `assemble_rows` / `_assemble_B_full`**: scaled COO-triplet accumulation with one `sparse()` per pencil, replacing a full-size sparse `+` per component. Derived terms scatter their triplets directly — no `place_in_block` full-system temporary per term.
- **`assemble_rows` (distributed)**: derived terms are row-restricted **before** the `coeff_mat * H(k) * rhs_mat` product, and H(k) is skipped entirely on ranks that own no derived-equation rows. Previously every rank computed the full near-dense triple product and threw away non-owned rows — derived-term cost did not shrink with rank count, undermining the #97 row distribution.
- **`reconstruct`**: H(k) (size-capped, near-dense) and the discretized RHS term matrices are memoized on the cache keyed by `(field, k)` / field — `reconstruct_all` over m eigenvectors paid m× block inverses + DSL lowering, now 1×. `DiscretizationCache` gains a `reconstruct_memo` field (constructors updated).
- **`chebyshev_coefficients`**: memoized FFTW `r2r` plan per length — was re-planning the DCT on every call, and it is called O(N_y) times per y-varying field.

## Setup path (per discretize)

- Removed **dead `derived_H_k0`**: dense block inverses computed per derived variable at discretize time and never read anywhere — the dominant cost in the 18× above.
- BC application: one O(nnz) zeroing pass per component + COO-batched BC-row insertion (replaces per-row sparse assignment and elementwise sparse `+=`, the O(nnz)-shift insertion antipattern).
- Batched `fft(f_physical, 2)` in the 2D field-multiply builds (was a per-z-row FFT loop with slice copies); nested-derivative `S⁻¹` routed through the existing `ctx.sinv_1d_cache` at the two sites that bypassed it.
- `differentiate`: sparse `UpperTriangular` back-substitution instead of `Matrix(S) \ dc` (dense O(N³) LU of a banded triangular operator); dropped the cancelling `1/N`–`N` fft scaling pair.
- `multiplication_operator`: coefficient filter hoisted out of the O(N·nf) loop + sizehints; ultraspherical recurrence skips the axpy for negligible coefficients; redundant sparse copy dropped.
- `sparse_from_csr`: direct CSC-of-transpose rebuild (no COO re-sort); `_to_csr` drops a redundant `nzval` copy.
- `utils`/`results`: type-stable selector functions for `sort_evals`/`remove_evals`; singular-B mode filter computes one `B*Χ` product instead of a sparse mat-vec per mode.

## Deliberately not changed

- `build_bc_rows` dense row records (setup-once, larger refactor)
- `discretize_expr` dense matrix-parameter branch (sparse-wrapping a genuinely dense user operator could ~3× its memory)
- `KPowerKey` abstract dict key (dicts are tiny; profile first)

## Test plan

- [x] Full suite: 1313/1313 pass on this branch (rebased on `main` incl. #100/#101)
- [x] A/B fingerprints identical at Nx=64/Nz=24 and Nx=180/Nz=30: `|sum(A)|`, `|sum(B)|`, `nnz(A)`, and reconstructed `u/v/bx/by` norms
- [ ] `mpi.yml` CI (distributed `assemble_rows` path is exercised by existing rank-sliced equality tests in `test_mpi_prep.jl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)